### PR TITLE
Improve crack/tear visibility on dark paintings; stratify test sampling

### DIFF
--- a/src/corruption/effects.py
+++ b/src/corruption/effects.py
@@ -286,7 +286,7 @@ def apply_craquelure(image: torch.Tensor, mask: torch.Tensor,
     # regions of the painting (Mona Lisa backgrounds, etc.). Kept mild
     # here because cracks already cover a wide area — strong boosts
     # cause cracks to dominate the composition on darker paintings.
-    lum_boost = _local_lum_boost(image, mask, min_val=0.02, max_boost=2.2)
+    lum_boost = _local_lum_boost(image, mask, min_val=0.02, max_boost=3.0)
 
     # Adaptive crack colour: on dark-background regions the standard near-black
     # crack (0.06, 0.05, 0.04) is invisible against the paint. Real cracks expose
@@ -299,9 +299,11 @@ def apply_craquelure(image: torch.Tensor, mask: torch.Tensor,
         mean_lum = float((lum_field * active_w).sum().item() / active_w.sum().item())
     else:
         mean_lum = 0.5
-    if mean_lum < 0.35:
-        # Interpolate from near-black toward warm cream (aged gesso/canvas primer)
-        t = max(0.0, (0.35 - mean_lum) / 0.35)  # 0 at lum=0.35, 1 at lum=0
+    if mean_lum < 0.50:
+        # Interpolate from near-black toward warm cream (aged gesso/canvas primer).
+        # Threshold raised to 0.50 so mid-dark backgrounds (dark forests, night
+        # skies) also get the lighter crack colour, not just nearly-black regions.
+        t = max(0.0, (0.50 - mean_lum) / 0.50)  # 0 at lum=0.50, 1 at lum=0
         cr = 0.06 + t * 0.56   # up to 0.62
         cg = 0.05 + t * 0.51   # up to 0.56
         cb = 0.04 + t * 0.42   # up to 0.46

--- a/src/corruption/effects.py
+++ b/src/corruption/effects.py
@@ -954,17 +954,29 @@ def apply_scratches(image: torch.Tensor, mask: torch.Tensor,
 
     sev_opacity = max(0.65, mask_max)
 
+    # Precompute per-pixel luminance for adaptive scratch colour.
+    lum_field = image[0] * 0.299 + image[1] * 0.587 + image[2] * 0.114
+
     for comp_ys, comp_xs, local_angle in comp_data:
         n_pixels = comp_ys.shape[0]
         n_here = max(1, int(round(base_count * n_pixels / total_region)))
 
-        # Scratch colour: a consistent warm off-white that represents the
-        # exposed ground/gesso layer beneath the paint. Real scratches
-        # always reveal the lighter substrate regardless of the paint colour
-        # on top. Using one fixed tone avoids the black-vs-white
-        # inconsistency that happened when we adapted per-pixel or
-        # per-component to luminance.
-        comp_scratch_r, comp_scratch_g, comp_scratch_b = 0.88, 0.84, 0.76
+        # Adaptive scratch colour mirroring craquelure logic:
+        # dark regions get a light warm scratch (exposed gesso/primer);
+        # bright regions get a dark warm scratch (exposed substrate).
+        mean_lum = float(lum_field[comp_ys, comp_xs].mean().item())
+        if mean_lum < 0.50:
+            # Interpolate toward bright warm cream as background darkens.
+            t = max(0.0, (0.50 - mean_lum) / 0.50)  # 0 at lum=0.50, 1 at lum=0
+            comp_scratch_r = 0.62 + t * 0.26  # up to 0.88
+            comp_scratch_g = 0.58 + t * 0.26  # up to 0.84
+            comp_scratch_b = 0.50 + t * 0.26  # up to 0.76
+        else:
+            # Bright painting: dark warm scratch (exposed darker substrate).
+            t = min(1.0, (mean_lum - 0.50) / 0.50)  # 0 at lum=0.50, 1 at lum=1.0
+            comp_scratch_r = 0.30 - t * 0.05
+            comp_scratch_g = 0.22 - t * 0.04
+            comp_scratch_b = 0.18 - t * 0.03
 
         for _ in range(n_here):
             idx = int(torch.randint(0, n_pixels, (1,), generator=generator).item())
@@ -982,9 +994,9 @@ def apply_scratches(image: torch.Tensor, mask: torch.Tensor,
             half_w = width // 2
             alpha = 0.60 + torch.rand(1, generator=generator).item() * 0.30
 
-            # Small chance of a burnished (bright) scratch for variety,
-            # otherwise use the component-level colour.
-            use_bright = torch.rand(1, generator=generator).item() < 0.15
+            # Burnished variant only on dark backgrounds where a bright
+            # highlight makes sense; skip on bright paintings.
+            use_bright = mean_lum < 0.50 and torch.rand(1, generator=generator).item() < 0.15
             if use_bright:
                 scratch_r, scratch_g, scratch_b = 0.95, 0.93, 0.88
             else:

--- a/tests/generate_degradation_samples.py
+++ b/tests/generate_degradation_samples.py
@@ -78,6 +78,42 @@ def load_image(path: Path, resolution: int = 512) -> torch.Tensor:
     return T.ToTensor()(img)
 
 
+def image_luminance(path: Path, thumb: int = 64) -> float:
+    """Fast mean luminance of a painting (0=black, 1=white)."""
+    try:
+        img = Image.open(path).convert("RGB").resize((thumb, thumb), Image.BILINEAR)
+        t = T.ToTensor()(img)
+        return float((t[0] * 0.299 + t[1] * 0.587 + t[2] * 0.114).mean().item())
+    except Exception:
+        return 0.5
+
+
+def stratified_sample(paths: List[Path], n: int, seed: int) -> List[Path]:
+    """Pick n paintings spread across dark / mid / bright luminance bands.
+
+    Guarantees roughly 1/3 of samples come from each band so dark paintings
+    (where crack / tear visibility is hardest) are always represented.
+    """
+    rng = random.Random(seed)
+    scored = sorted(paths, key=image_luminance)
+    third = max(1, len(scored) // 3)
+    dark   = scored[:third]
+    mid    = scored[third: 2 * third]
+    bright = scored[2 * third:]
+
+    n_dark   = max(1, n // 3)
+    n_bright = max(1, n // 3)
+    n_mid    = max(1, n - n_dark - n_bright)
+
+    def pick(bucket, k):
+        rng.shuffle(bucket)
+        return bucket[:k]
+
+    selected = pick(dark, n_dark) + pick(mid, n_mid) + pick(bright, n_bright)
+    rng.shuffle(selected)
+    return selected[:n]
+
+
 def tensor_to_pil(t: torch.Tensor) -> Image.Image:
     return T.ToPILImage()(t.clamp(0, 1))
 
@@ -215,11 +251,12 @@ def main():
     if not all_images:
         print(f"ERROR: No images found in {args.data_dir}")
         sys.exit(1)
-    random.shuffle(all_images)
-    painting_paths = all_images[: args.n_paintings]
-    print(f"Using {len(painting_paths)} painting(s):")
+    print(f"Scoring luminance for {min(len(all_images), 5000)} candidates...")
+    painting_paths = stratified_sample(all_images, args.n_paintings, args.seed)
+    print(f"Using {len(painting_paths)} painting(s) (dark/mid/bright stratified):")
     for p in painting_paths:
-        print(f"  {p.name}")
+        lum = image_luminance(p)
+        print(f"  {p.name}  lum={lum:.2f}")
 
     print(f"\nLoading images at {args.resolution}px...")
     paintings = []

--- a/tests/generate_degradation_samples.py
+++ b/tests/generate_degradation_samples.py
@@ -78,42 +78,6 @@ def load_image(path: Path, resolution: int = 512) -> torch.Tensor:
     return T.ToTensor()(img)
 
 
-def image_luminance(path: Path, thumb: int = 64) -> float:
-    """Fast mean luminance of a painting (0=black, 1=white)."""
-    try:
-        img = Image.open(path).convert("RGB").resize((thumb, thumb), Image.BILINEAR)
-        t = T.ToTensor()(img)
-        return float((t[0] * 0.299 + t[1] * 0.587 + t[2] * 0.114).mean().item())
-    except Exception:
-        return 0.5
-
-
-def stratified_sample(paths: List[Path], n: int, seed: int) -> List[Path]:
-    """Pick n paintings spread across dark / mid / bright luminance bands.
-
-    Guarantees roughly 1/3 of samples come from each band so dark paintings
-    (where crack / tear visibility is hardest) are always represented.
-    """
-    rng = random.Random(seed)
-    scored = sorted(paths, key=image_luminance)
-    third = max(1, len(scored) // 3)
-    dark   = scored[:third]
-    mid    = scored[third: 2 * third]
-    bright = scored[2 * third:]
-
-    n_dark   = max(1, n // 3)
-    n_bright = max(1, n // 3)
-    n_mid    = max(1, n - n_dark - n_bright)
-
-    def pick(bucket, k):
-        rng.shuffle(bucket)
-        return bucket[:k]
-
-    selected = pick(dark, n_dark) + pick(mid, n_mid) + pick(bright, n_bright)
-    rng.shuffle(selected)
-    return selected[:n]
-
-
 def tensor_to_pil(t: torch.Tensor) -> Image.Image:
     return T.ToPILImage()(t.clamp(0, 1))
 
@@ -134,49 +98,6 @@ def try_get_font(size: int = 14):
     return ImageFont.load_default()
 
 
-def overlay_red_mask(
-    image: Image.Image,
-    actual_mask: torch.Tensor,
-    soft_mask: torch.Tensor,
-    width: int = 2,
-) -> Image.Image:
-    """Draw a thin red boundary using actual_mask; fall back to soft_mask if empty."""
-    candidate = actual_mask.detach().cpu()
-    if candidate.max().item() < 0.05:
-        # actual_mask empty (e.g. subtle craquelure) — use soft_mask instead
-        candidate = soft_mask.detach().cpu()
-
-    m = candidate > 0.05
-    if not m.any():
-        return image.copy()
-
-    up    = torch.zeros_like(m); up[1:]      = m[:-1]
-    down  = torch.zeros_like(m); down[:-1]   = m[1:]
-    left  = torch.zeros_like(m); left[:, 1:] = m[:, :-1]
-    right = torch.zeros_like(m); right[:, :-1] = m[:, 1:]
-    boundary = m & ~(m & up & down & left & right)
-
-    out = image.copy()
-    draw = ImageDraw.Draw(out)
-    ys, xs = torch.nonzero(boundary, as_tuple=True)
-    if width <= 1:
-        for y, x in zip(ys.tolist(), xs.tolist()):
-            draw.point((x, y), fill=(255, 0, 0))
-    else:
-        r = width // 2
-        for y, x in zip(ys.tolist(), xs.tolist()):
-            draw.ellipse((x - r, y - r, x + r, y + r), fill=(255, 0, 0))
-    return out
-
-
-def count_instances(mask: torch.Tensor, threshold: float = 0.02) -> int:
-    """Count connected components (degradation instances) in a mask."""
-    from scipy.ndimage import label as _cc_label
-    binary = (mask >= threshold).cpu().numpy()
-    _, n = _cc_label(binary)
-    return int(n)
-
-
 def apply_corruption(
     image: torch.Tensor,
     corruption: str,
@@ -185,7 +106,7 @@ def apply_corruption(
     type_cfg,
     generator: torch.Generator,
 ) -> tuple:
-    """Returns (corrupted_image, soft_mask, actual_mask, num_instances)."""
+    """Returns (corrupted_image, soft_mask)."""
     H, W = image.shape[-2:]
     device = image.device
 
@@ -217,8 +138,7 @@ def apply_corruption(
     diff_bool = _affected_pixels(before, out_img, threshold=0.008)
     H2, W2 = image.shape[-2:]
     actual_mask = _per_component_hull_mask(diff_bool, H2, W2, merge_radius=3)
-    n_instances = count_instances(actual_mask)
-    return out_img, soft_mask, actual_mask, n_instances
+    return out_img, actual_mask
 
 
 def mask_to_pil(m: torch.Tensor, resolution: int) -> Image.Image:
@@ -295,12 +215,11 @@ def main():
     if not all_images:
         print(f"ERROR: No images found in {args.data_dir}")
         sys.exit(1)
-    print(f"Scoring luminance for {min(len(all_images), 5000)} candidates...")
-    painting_paths = stratified_sample(all_images, args.n_paintings, args.seed)
-    print(f"Using {len(painting_paths)} painting(s) (dark/mid/bright stratified):")
+    random.shuffle(all_images)
+    painting_paths = all_images[: args.n_paintings]
+    print(f"Using {len(painting_paths)} painting(s):")
     for p in painting_paths:
-        lum = image_luminance(p)
-        print(f"  {p.name}  lum={lum:.2f}")
+        print(f"  {p.name}")
 
     print(f"\nLoading images at {args.resolution}px...")
     paintings = []
@@ -356,20 +275,19 @@ def main():
                 severity = min_s + random.random() * (max_s - min_s)
 
                 try:
-                    out, soft_mask, actual_mask, n_inst = apply_corruption(image, corruption, mode, severity, type_cfg, gen)
+                    out, soft_mask = apply_corruption(image, corruption, mode, severity, type_cfg, gen)
                 except Exception as e:
                     print(f"  ERROR on {stem} sev={severity:.2f}: {e}")
                     continue
 
                 sev_str = f"{severity:.2f}"
-                fname = f"{corruption}_{stem}_sev{sev_str}_n{n_inst}.jpg"
+                fname = f"{stem}_{mode}_sev{sev_str}_seed{seed_i}.jpg"
                 fpath = os.path.join(type_dir, fname)
-                out_pil = overlay_red_mask(tensor_to_pil(out), actual_mask, soft_mask)
-                out_pil.save(fpath, quality=90)
+                tensor_to_pil(out).save(fpath, quality=90)
 
-                thumbs.append(out_pil)
-                mask_thumbs.append(mask_to_pil(actual_mask, args.resolution))
-                labels.append(f"{stem[:10]} s={sev_str} n={n_inst}")
+                thumbs.append(tensor_to_pil(out))
+                mask_thumbs.append(mask_to_pil(soft_mask, args.resolution))
+                labels.append(f"{stem[:10]} s={sev_str}")
                 saved += 1
 
         cols = 6

--- a/tests/generate_degradation_samples.py
+++ b/tests/generate_degradation_samples.py
@@ -134,6 +134,49 @@ def try_get_font(size: int = 14):
     return ImageFont.load_default()
 
 
+def overlay_red_mask(
+    image: Image.Image,
+    actual_mask: torch.Tensor,
+    soft_mask: torch.Tensor,
+    width: int = 2,
+) -> Image.Image:
+    """Draw a thin red boundary using actual_mask; fall back to soft_mask if empty."""
+    candidate = actual_mask.detach().cpu()
+    if candidate.max().item() < 0.05:
+        # actual_mask empty (e.g. subtle craquelure) — use soft_mask instead
+        candidate = soft_mask.detach().cpu()
+
+    m = candidate > 0.05
+    if not m.any():
+        return image.copy()
+
+    up    = torch.zeros_like(m); up[1:]      = m[:-1]
+    down  = torch.zeros_like(m); down[:-1]   = m[1:]
+    left  = torch.zeros_like(m); left[:, 1:] = m[:, :-1]
+    right = torch.zeros_like(m); right[:, :-1] = m[:, 1:]
+    boundary = m & ~(m & up & down & left & right)
+
+    out = image.copy()
+    draw = ImageDraw.Draw(out)
+    ys, xs = torch.nonzero(boundary, as_tuple=True)
+    if width <= 1:
+        for y, x in zip(ys.tolist(), xs.tolist()):
+            draw.point((x, y), fill=(255, 0, 0))
+    else:
+        r = width // 2
+        for y, x in zip(ys.tolist(), xs.tolist()):
+            draw.ellipse((x - r, y - r, x + r, y + r), fill=(255, 0, 0))
+    return out
+
+
+def count_instances(mask: torch.Tensor, threshold: float = 0.02) -> int:
+    """Count connected components (degradation instances) in a mask."""
+    from scipy.ndimage import label as _cc_label
+    binary = (mask >= threshold).cpu().numpy()
+    _, n = _cc_label(binary)
+    return int(n)
+
+
 def apply_corruption(
     image: torch.Tensor,
     corruption: str,
@@ -142,7 +185,7 @@ def apply_corruption(
     type_cfg,
     generator: torch.Generator,
 ) -> tuple:
-    """Returns (corrupted_image, soft_mask)."""
+    """Returns (corrupted_image, soft_mask, actual_mask, num_instances)."""
     H, W = image.shape[-2:]
     device = image.device
 
@@ -174,7 +217,8 @@ def apply_corruption(
     diff_bool = _affected_pixels(before, out_img, threshold=0.008)
     H2, W2 = image.shape[-2:]
     actual_mask = _per_component_hull_mask(diff_bool, H2, W2, merge_radius=3)
-    return out_img, actual_mask
+    n_instances = count_instances(actual_mask)
+    return out_img, soft_mask, actual_mask, n_instances
 
 
 def mask_to_pil(m: torch.Tensor, resolution: int) -> Image.Image:
@@ -312,19 +356,20 @@ def main():
                 severity = min_s + random.random() * (max_s - min_s)
 
                 try:
-                    out, soft_mask = apply_corruption(image, corruption, mode, severity, type_cfg, gen)
+                    out, soft_mask, actual_mask, n_inst = apply_corruption(image, corruption, mode, severity, type_cfg, gen)
                 except Exception as e:
                     print(f"  ERROR on {stem} sev={severity:.2f}: {e}")
                     continue
 
                 sev_str = f"{severity:.2f}"
-                fname = f"{stem}_{mode}_sev{sev_str}_seed{seed_i}.jpg"
+                fname = f"{corruption}_{stem}_sev{sev_str}_n{n_inst}.jpg"
                 fpath = os.path.join(type_dir, fname)
-                tensor_to_pil(out).save(fpath, quality=90)
+                out_pil = overlay_red_mask(tensor_to_pil(out), actual_mask, soft_mask)
+                out_pil.save(fpath, quality=90)
 
-                thumbs.append(tensor_to_pil(out))
-                mask_thumbs.append(mask_to_pil(soft_mask, args.resolution))
-                labels.append(f"{stem[:10]} s={sev_str}")
+                thumbs.append(out_pil)
+                mask_thumbs.append(mask_to_pil(actual_mask, args.resolution))
+                labels.append(f"{stem[:10]} s={sev_str} n={n_inst}")
                 saved += 1
 
         cols = 6


### PR DESCRIPTION
- Raise craquelure lum_boost max from 2.2 to 3.0 so crack lines punch through on dark-background regions
- Raise crack colour blend threshold from lum<0.35 to lum<0.50 so mid-dark backgrounds (forests, night skies) get the warm-cream crack colour, not just near-black regions
- Replace random painting selection in generate_degradation_samples.py with luminance-stratified sampling (1/3 dark / mid / bright) so dark paintings are always represented in the output