### PR TITLE
'fixed corruption sampling; changed warm up; forward pass test'

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ src/
 ├── null_emb.py        # Precompute and cache null text embedding
 ├── inference.py       # ODE sampling + data consistency
 ├── evaluations.py     # PSNR and stratified per-damage-type metrics
-├── train.py           # Training loop (warmup + full stage)
+├── train.py           # Training loop with iteration-based warm-up
 └── flux2/             # Verbatim source from black-forest-labs/flux2
 
 tools/
@@ -72,8 +72,8 @@ train/
 ├── configs/
 │   └── train.yaml     # Training hyperparameters
 └── scripts/
-    ├── warmup.sh      # SLURM: stage 1 (img_in only)
-    └── full.sh        # SLURM: stage 2 (all layers)
+    ├── warmup.sh      # SLURM: start training from scratch
+    └── full.sh        # SLURM: resume from a saved checkpoint
 
 inference/
 ├── configs/
@@ -99,12 +99,16 @@ Download datasets and place them at the paths set in `train/configs/train.yaml`:
 
 ## Training
 
-Training has two stages controlled by `train.stage` in `train/configs/train.yaml`:
+Training starts with `img_in`-only warm-up for `train.warmup_iterations` optimizer steps,
+then automatically unfreezes the backbone and switches to the full-training learning rates.
+`train.warmup_iterations` is evaluated when training starts or resumes from checkpoint.
+If you change it mid-run, the live process will not notice; stop and resume from a checkpoint
+to apply the new value.
 
-| Stage | What trains | LR key |
-|-------|-------------|--------|
-| `warmup` | `img_in` only (backbone frozen) | `train.warmup.lr` |
-| `full` | All layers | `train.full.backbone_lr` / `train.full.img_in_lr` |
+| Phase | What trains | Config key |
+|-------|-------------|------------|
+| Warm-up | `img_in` only (backbone frozen) | `train.warmup_iterations`, `train.warmup.lr` |
+| Full training | All layers | `train.full.backbone_lr` / `train.full.img_in_lr` |
 
 See `train/scripts/warmup.sh` and `train/scripts/full.sh`.
 

--- a/src/corruption/configs/default.yaml
+++ b/src/corruption/configs/default.yaml
@@ -1,7 +1,8 @@
 # Corruption pipeline configuration.
 #
-# Each sample: a random subset of `num_simultaneous.[min, max]` types is
-# selected using per-type weights. For each selected type, the mask is
+# Each sample: the number of active degradation types is drawn from
+# `active_count_probs`, then that many types are selected using per-type weights.
+# For each selected type, the mask is
 # generated in either "local" (scattered irregular shapes) or "global"
 # (uniform fill) mode, uniformly at random among the modes enabled for
 # that type. Severity is drawn uniformly in [min_severity, max_severity].
@@ -20,10 +21,9 @@
 #   scratches  -> 'scratches' : narrow elongated band. Half-width scales
 #                              with severity.
 
-# Range of how many distinct types are active per image.
-num_simultaneous:
-  min: 1
-  max: 3
+# Probability that exactly N degradation types are active, for N = 1..7.
+# Entries are normalized internally, so they only need to be non-negative.
+active_count_probs: [0.333333, 0.333333, 0.333334, 0.0, 0.0, 0.0, 0.0]
 
 # Training only: zero per-type mask channels with this probability (union channel kept).
 # Overridden by `corruption.dropout_prob` in the training YAML when merged.

--- a/src/corruption/configs/default.yaml
+++ b/src/corruption/configs/default.yaml
@@ -23,7 +23,7 @@
 
 # Probability that exactly N degradation types are active, for N = 1..7.
 # Entries are normalized internally, so they only need to be non-negative.
-active_count_probs: [0.333333, 0.333333, 0.333334, 0.0, 0.0, 0.0, 0.0]
+active_count_probs: [0.35, 0.25, 0.15, 0.1, 0.075, 0.05, 0.025]
 
 # Training only: zero per-type mask channels with this probability (union channel kept).
 # Overridden by `corruption.dropout_prob` in the training YAML when merged.

--- a/src/corruption/module.py
+++ b/src/corruption/module.py
@@ -2,8 +2,9 @@
 
 Per-sample stochastic pipeline:
 
-  1. Pick N ~ Uniform[cfg.num_simultaneous.min, cfg.num_simultaneous.max]
-     distinct channel names, weighted by each channel's `weight`.
+  1. Pick N according to ``cfg.active_count_probs`` (or legacy
+     ``cfg.num_simultaneous``), then sample that many distinct channel names
+     weighted by each channel's ``weight``.
   2. For each chosen channel c:
         - Pick mode ∈ {local, global} among enabled modes (uniform).
         - Pick severity ~ Uniform[c.min_severity, c.max_severity].
@@ -144,7 +145,8 @@ class CorruptionModule:
 
     Args:
         config: DictConfig or dict with keys:
-            num_simultaneous: {min, max}
+            active_count_probs: list of 7 non-negative weights for selecting
+                exactly 1..7 active degradations
             types: dict mapping channel name -> {
                 weight, local_enabled, global_enabled,
                 min_severity, max_severity,
@@ -171,10 +173,25 @@ class CorruptionModule:
 
     def _sample_active_channels(self, generator: torch.Generator) -> List[str]:
         """Pick N distinct channel names with probability proportional to weight."""
-        ns = self.config['num_simultaneous']
-        n_lo, n_hi = int(ns['min']), int(ns['max'])
-        n_hi = max(n_lo, min(n_hi, NUM_CHANNELS))
-        n = n_lo + int(torch.randint(0, n_hi - n_lo + 1, (1,), generator=generator).item())
+        count_probs = self.config.get("active_count_probs")
+        if count_probs is not None:
+            probs = torch.tensor(list(count_probs), dtype=torch.float32)
+            if probs.numel() != NUM_CHANNELS:
+                raise ValueError(
+                    f"active_count_probs must have exactly {NUM_CHANNELS} entries, "
+                    f"got {probs.numel()}."
+                )
+            probs = probs.clamp(min=0)
+            total = float(probs.sum().item())
+            if total <= 0.0:
+                raise ValueError("active_count_probs must contain at least one positive value.")
+            probs = probs / total
+            n = int(torch.multinomial(probs, 1, generator=generator).item()) + 1
+        else:
+            ns = self.config['num_simultaneous']
+            n_lo, n_hi = int(ns['min']), int(ns['max'])
+            n_hi = max(n_lo, min(n_hi, NUM_CHANNELS))
+            n = n_lo + int(torch.randint(0, n_hi - n_lo + 1, (1,), generator=generator).item())
         if n <= 0:
             return []
 

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -36,7 +36,6 @@ class ArtRestorationDataset(Dataset):
         data_dir: str,
         resolution: int,
         corruption_config: Any,
-        max_simultaneous: Optional[int] = None,
         split: str = "train",
         corruption_seed: int = 42,
         deterministic_corruption: Optional[bool] = None,
@@ -55,10 +54,7 @@ class ArtRestorationDataset(Dataset):
             else bool(deterministic_corruption)
         )
 
-        cfg = copy.deepcopy(corruption_config)
-        if max_simultaneous == 1:
-            cfg.individual_prob = 1.0
-        self.corruptor = CorruptionModule(cfg)
+        self.corruptor = CorruptionModule(copy.deepcopy(corruption_config))
 
         self.image_paths = _find_images(self.data_dir)
         self._base_corruption_seed = int(corruption_seed)
@@ -397,7 +393,6 @@ def build_wikiart_dataloader(
     corruption_config: Any,
     batch_size: int,
     split: str = "train",
-    max_simultaneous: Optional[int] = None,
     num_workers: int = 0,
     sampler_seed: int = 42,
     corruption_seed: int = 42,
@@ -428,7 +423,6 @@ def build_wikiart_dataloader(
         data_dir=image_dir,
         resolution=resolution,
         corruption_config=corruption_config,
-        max_simultaneous=max_simultaneous,
         split=canonical_split,
         corruption_seed=_offset_seed_for_rank(corruption_seed, resolved_rank),
         deterministic_corruption=deterministic_corruption,

--- a/src/model.py
+++ b/src/model.py
@@ -26,9 +26,9 @@ Forward input/output:
     null_emb: (1, 512, 7680)     precomputed null text embedding
     output:   (B, 128, H', W')   predicted velocity v_θ
 
-Training stages (controlled via set_stage):
-    "warmup": backbone frozen, only img_in.requires_grad = True
-    "full":   all parameters trainable
+Warm-up mode:
+    For the first configured training iterations, backbone weights stay frozen and
+    only ``img_in`` is trainable. After that, all parameters are trainable.
 """
 
 import torch
@@ -37,7 +37,7 @@ from einops import rearrange
 from torch import Tensor
 from typing import Any, List
 
-from .flux2.model import Flux2, Klein4BParams
+from .flux2.model import Flux2
 from .flux2.sampling import batched_prc_img, batched_prc_txt
 from .flux2.util import init_flow_model, load_pretrained_flow_weights
 
@@ -179,21 +179,14 @@ class RestorationDiT(nn.Module):
         return vel.to(dtype=z_t.dtype)
         
             
-    def set_stage(self, stage: str) -> None:
-        """Freeze or unfreeze parameters for the given training stage.
-
-        Args:
-            stage: "warmup" → freeze all except img_in.
-                   "full"   → unfreeze all parameters.
-        """
-        if stage == "warmup": 
-            for name, p in self.flow_model.named_parameters(): 
+    def set_trainability(self, warmup_only: bool) -> None:
+        """Freeze backbone params during warm-up, or unfreeze everything afterward."""
+        if warmup_only:
+            for name, p in self.flow_model.named_parameters():
                 p.requires_grad = name.startswith("img_in")
-        elif stage == "full":
-            for p in self.flow_model.parameters(): 
-                p.requires_grad_(True)
-        else: 
-            raise ValueError(f"Unknown stage {stage!r}; expected 'warmup' or 'full'")
+            return
+        for p in self.flow_model.parameters():
+            p.requires_grad_(True)
 
     def get_trainable_params(self) -> List[dict]:
         """Return optimizer param groups with 'params' and 'name' keys.
@@ -202,7 +195,7 @@ class RestorationDiT(nn.Module):
             {"params": img_in_params,   "name": "img_in"}
             {"params": backbone_params, "name": "backbone"}
 
-        The caller sets per-group LRs based on the training stage.
+        The caller sets per-group LRs based on the current warm-up/full phase.
 
         Returns:
             List of two param group dicts.

--- a/src/train.py
+++ b/src/train.py
@@ -12,15 +12,11 @@ Rectified flow objective per training step:
        union-mask vs outside; see :func:`compute_flow_loss`.
     8. ``engine.backward`` / ``engine.step`` (DeepSpeed); LR scheduler stepped by DeepSpeed.
 
-Training stages (``cfg.train.stage``):
-    ``"warmup"``: backbone frozen; only ``img_in`` trained at ``cfg.train.warmup.lr``.
-    ``"full"``:   all layers trainable; backbone at ``cfg.train.full.backbone_lr``,
-                  ``img_in`` at ``cfg.train.full.img_in_lr``.
-
-Curriculum (``cfg.train.curriculum.enabled``):
-    For the first ``curriculum.warmup_epochs`` epochs, ``max_simultaneous=1`` is applied
-    by forcing ``individual_prob = 1.0`` in a copy of the corruption config so the
-    dataloader favours single-degradation corruptions.
+Warm-up:
+    For the first ``cfg.train.warmup_iterations`` optimizer steps, backbone weights stay
+    frozen and only ``img_in`` is trained at ``cfg.train.warmup.lr``. After that,
+    all layers are trainable and the optimizer switches to
+    ``cfg.train.full.backbone_lr`` / ``cfg.train.full.img_in_lr``.
 
 Distributed training:
     Launch with ``torchrun`` / DeepSpeed so ``RANK``, ``LOCAL_RANK``, and ``WORLD_SIZE``
@@ -46,7 +42,7 @@ Usage:
 
 Arguments:
     --config    Path to YAML (default: ``train/configs/train.yaml``).
-    overrides   Dot-notation overrides, e.g. ``train.stage=full``,
+    overrides   Dot-notation overrides, e.g. ``train.warmup_iterations=1000``,
                 ``ds_config.train_micro_batch_size_per_gpu=8``,
                 ``train.resume_from=/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/checkpoints/step_1000``.
 """
@@ -162,17 +158,19 @@ def setup_model(
     cfg: DictConfig,
     device: torch.device,
     rank: int,
+    warmup_only: bool,
     load_pretrained: bool = True,
 ) -> tuple[RestorationDiT, FluxVAE, torch.Tensor]:
     """Construct the restoration DiT, frozen FLUX VAE, and cached null text embedding.
 
-    Calls ``model.set_stage(cfg.train.stage)`` so only the intended parameters require
-    gradients before the optimizer is built.
+    Calls ``model.set_trainability(warmup_only)`` so only the intended parameters
+    require gradients before the optimizer is built.
 
     Args:
-        cfg:    Full OmegaConf ``DictConfig`` (uses ``cfg.model`` and ``cfg.train.stage``).
+        cfg:    Full OmegaConf ``DictConfig`` (uses ``cfg.model`` and ``cfg.train``).
         device: CUDA device for this process (typically ``cuda:LOCAL_RANK``).
         rank:   Global rank, forwarded to weight download logging and VAE init.
+        warmup_only: Whether training should start in img_in-only warm-up mode.
         load_pretrained: Whether to load FLUX pretrained weights before widening ``img_in``.
 
     Returns:
@@ -186,7 +184,7 @@ def setup_model(
         load_pretrained=load_pretrained,
         rank=rank,
     )
-    flow_model.set_stage(cfg.train.stage)
+    flow_model.set_trainability(warmup_only)
 
     vae = FluxVAE(
         flux_model_name=cfg.model.flux_model_name,
@@ -201,34 +199,35 @@ def setup_model(
     return flow_model, vae, null_emb
 
 
-def build_optimizer(model: RestorationDiT, cfg: DictConfig) -> torch.optim.Optimizer:
-    """Build AdamW with learning rates appropriate for the current training stage.
+def build_optimizer(
+    model: RestorationDiT,
+    cfg: DictConfig,
+    warmup_only: bool,
+) -> torch.optim.Optimizer:
+    """Build AdamW for either warm-up or full training.
 
-    Warmup stage → single param group: all trainable ``img_in`` weights at
-    ``cfg.train.warmup.lr`` (backbone should already be frozen via ``set_stage``).
-
-    Full stage → two groups from ``model.get_trainable_params()``:
-        ``img_in`` at ``cfg.train.full.img_in_lr``, backbone at ``cfg.train.full.backbone_lr``.
+    Warm-up keeps the backbone frozen and sets its optimizer LR to zero. After warm-up,
+    ``img_in`` and backbone use their full-training learning rates.
 
     Weight decay and Adam ``betas`` come from ``cfg.train.optimizer``.
 
     Args:
-        model: ``RestorationDiT`` with ``requires_grad`` flags already set for the stage.
+        model: ``RestorationDiT`` with ``requires_grad`` flags already set for the phase.
         cfg:   Full config.
+        warmup_only: Whether to start in img_in-only warm-up mode.
 
     Returns:
         A ``torch.optim.AdamW`` instance suitable for passing to ``deepspeed.initialize``.
     """
     wd = cfg.train.optimizer.weight_decay
     betas = tuple(cfg.train.optimizer.betas)
-    if cfg.train.stage == "warmup":
-        params = [p for p in model.flow_model.img_in.parameters() if p.requires_grad]
-        return torch.optim.AdamW(params, lr=cfg.train.warmup.lr, betas=betas, weight_decay=wd)
     groups = model.get_trainable_params()
+    img_in_lr = float(cfg.train.warmup.lr) if warmup_only else float(cfg.train.full.img_in_lr)
+    backbone_lr = 0.0 if warmup_only else float(cfg.train.full.backbone_lr)
     return torch.optim.AdamW(
         [
-            {"params": groups[0]["params"], "lr": cfg.train.full.img_in_lr, "name": "img_in"},
-            {"params": groups[1]["params"], "lr": cfg.train.full.backbone_lr, "name": "backbone"},
+            {"params": groups[0]["params"], "lr": img_in_lr, "name": "img_in"},
+            {"params": groups[1]["params"], "lr": backbone_lr, "name": "backbone"},
         ],
         betas=betas,
         weight_decay=wd,
@@ -243,7 +242,7 @@ def build_scheduler(
     """Cosine decay with linear warmup, implemented as a single ``LambdaLR`` multiplier.
 
     The multiplier applies equally to all param groups; their *absolute* LRs differ
-    if the optimizer used different base rates per group (full stage).
+    if the optimizer used different base rates per group.
 
     Warmup ramps the multiplier linearly from ``1/warmup_steps`` to ``1`` over
     ``warmup_steps``. Afterward a cosine drops the multiplier from ``1`` down to
@@ -325,9 +324,53 @@ def _distributed_barrier() -> None:
         dist.barrier()
 
 
+def _warmup_iterations(cfg: DictConfig) -> int:
+    return max(0, int(getattr(cfg.train, "warmup_iterations", 0)))
+
+
+def _warmup_only_for_step(cfg: DictConfig, step: int) -> bool:
+    return int(step) < _warmup_iterations(cfg)
+
+
+def _step_from_tag(tag: str | None) -> int:
+    if not tag:
+        return 0
+    try:
+        return max(0, int(str(tag).split("_", 1)[1]))
+    except (IndexError, ValueError):
+        return 0
+
+
+def _phase_lrs(cfg: DictConfig, warmup_only: bool) -> dict[str, float]:
+    return {
+        "img_in": float(cfg.train.warmup.lr) if warmup_only else float(cfg.train.full.img_in_lr),
+        "backbone": 0.0 if warmup_only else float(cfg.train.full.backbone_lr),
+    }
+
+
+def _apply_training_phase(
+    model: RestorationDiT,
+    optimizer: torch.optim.Optimizer,
+    scheduler: Any,
+    cfg: DictConfig,
+    step: int,
+) -> bool:
+    warmup_only = _warmup_only_for_step(cfg, step)
+    model.set_trainability(warmup_only)
+    lrs = _phase_lrs(cfg, warmup_only)
+    base_lrs: list[float] = []
+    for group in optimizer.param_groups:
+        lr = lrs.get(group.get("name", ""), float(group["lr"]))
+        group["lr"] = lr
+        group["initial_lr"] = lr
+        base_lrs.append(lr)
+    if scheduler is not None and hasattr(scheduler, "base_lrs"):
+        scheduler.base_lrs = list(base_lrs)
+    return warmup_only
+
+
 def setup_dataloader(
     cfg: DictConfig,
-    max_simultaneous: int | None = None,
     split: str = "train",
 ) -> tuple[DataLoader, ArtRestorationDataset]:
     """Create a train or val dataloader using the resumable dataset helpers."""
@@ -338,7 +381,6 @@ def setup_dataloader(
         corruption_config=cfg.corruption,
         batch_size=_micro_batch_size(cfg),
         split=split,
-        max_simultaneous=max_simultaneous,
         num_workers=int(getattr(cfg.train, "num_workers", 4)),
         sampler_seed=int(getattr(cfg.train, "sampler_seed", cfg.train.seed)),
         corruption_seed=int(getattr(cfg.train, "corruption_seed", cfg.train.seed)),
@@ -499,7 +541,7 @@ def _write_checkpoint_metadata(output_dir: Path, tag: str, client_state: dict) -
     Args:
         output_dir:   Root directory.
         tag:          Checkpoint tag, e.g. ``step_1000``.
-        client_state: Pickle-friendly dict (``step``, ``epoch``, ``stage``, etc.).
+        client_state: Pickle-friendly dict (``step``, ``epoch``, etc.).
     """
     if not is_main_process():
         return
@@ -543,20 +585,6 @@ def train(cfg: DictConfig) -> None:
     main(cfg)
 
 
-def _curriculum_max_sim(cfg: DictConfig, epoch: int) -> int | None:
-    """Return ``max_simultaneous`` mask for the dataset at ``epoch``, or ``None`` if disabled.
-
-    When curriculum is enabled and ``epoch < curriculum.warmup_epochs``, returns ``1``
-    so :class:`~src.dataset.ArtRestorationDataset` biases toward single-degradation
-    corruptions. Otherwise returns ``None`` (full preset statistics from YAML).
-    """
-    if not cfg.train.curriculum.get("enabled", False):
-        return None
-    if epoch < int(cfg.train.curriculum.warmup_epochs):
-        return 1
-    return None
-
-
 def _capture_train_loader_state(
     train_loader: DataLoader,
     train_dataset: ArtRestorationDataset,
@@ -596,7 +624,6 @@ def _restore_train_loader_state(
 def _build_train_loader(
     cfg: DictConfig,
     corrupt_cfg: DictConfig,
-    max_sim: int | None,
     world_size: int,
 ) -> tuple[DataLoader, ArtRestorationDataset, Any]:
     """Build the training dataloader plus its dataset and sampler."""
@@ -607,7 +634,6 @@ def _build_train_loader(
         corruption_config=corrupt_cfg,
         batch_size=_micro_batch_size(cfg),
         split="train",
-        max_simultaneous=max_sim,
         num_workers=int(getattr(cfg.train, "num_workers", 4)),
         sampler_seed=int(getattr(cfg.train, "sampler_seed", cfg.train.seed)),
         corruption_seed=int(getattr(cfg.train, "corruption_seed", cfg.train.seed)),
@@ -636,7 +662,6 @@ def _build_val_loader(
         corruption_config=corrupt_cfg,
         batch_size=_micro_batch_size(cfg),
         split="val",
-        max_simultaneous=None,
         num_workers=int(getattr(cfg.train, "num_workers", 4)),
         sampler_seed=int(getattr(cfg.train, "sampler_seed", cfg.train.seed)),
         corruption_seed=int(getattr(cfg.train, "corruption_seed", cfg.train.seed)),
@@ -693,9 +718,10 @@ def main(cfg: DictConfig) -> None:
         3. Build train & val dataloaders (DistributedSampler on train if multi-GPU).
         4. AdamW + LambdaLR, then ``deepspeed.initialize`` (ZeRO-2 + bf16 from YAML).
         5. Optional ``load_checkpoint`` resume.
-        6. Epoch loop: curriculum may rebuild the train loader; each step runs
+        6. Epoch loop: each step runs
            :func:`compute_flow_loss`, ``backward``, ``step``; periodic WandB logging,
-           distributed validation loss evaluation, and DeepSpeed saves on all ranks.
+           distributed validation loss evaluation, warm-up unfreeze when
+           ``train.warmup_iterations`` is reached, and DeepSpeed saves on all ranks.
 
     Args:
         cfg: Merged ``DictConfig`` from :func:`src.utils.load_config`.
@@ -717,24 +743,24 @@ def main(cfg: DictConfig) -> None:
 
     load_dir, load_tag = _resolve_checkpoint_strategy(cfg)
     should_try_checkpoint = load_dir is not None and load_tag is not None
+    initial_step_hint = _step_from_tag(load_tag)
+    warmup_only = _warmup_only_for_step(cfg, initial_step_hint)
 
     # --- Models: either checkpoint-first init (no pretrained) or pretrained fallback path ---
     flow_model, vae, null_emb = setup_model(
         cfg,
         device,
         rank,
+        warmup_only=warmup_only,
         load_pretrained=not should_try_checkpoint,
     )
     vae = vae.to(device).requires_grad_(False).eval()
 
     corrupt_cfg = cfg.corruption
 
-    # --- Data: train (possibly curriculum); val only on rank 0 to avoid duplicate work ---
+    # --- Data: train + val ---
     start_epoch = 0
-    max_sim = _curriculum_max_sim(cfg, start_epoch)
-    train_loader, train_dataset, train_sampler = _build_train_loader(
-        cfg, corrupt_cfg, max_sim, world_size
-    )
+    train_loader, train_dataset, train_sampler = _build_train_loader(cfg, corrupt_cfg, world_size)
     val_loader, _, val_sampler = _build_val_loader(cfg, corrupt_cfg, world_size)
 
     steps_per_epoch = max(len(train_loader), 1)
@@ -744,7 +770,7 @@ def main(cfg: DictConfig) -> None:
     )
 
     # --- Optimizer / scheduler / DeepSpeed engine (ZeRO partitioning lives here) ---
-    optimizer = build_optimizer(flow_model, cfg)
+    optimizer = build_optimizer(flow_model, cfg, warmup_only=warmup_only)
     scheduler = build_scheduler(optimizer, cfg, total_optimizer_steps)
 
     ds_cfg = OmegaConf.to_container(cfg.ds_config, resolve=True)
@@ -763,6 +789,7 @@ def main(cfg: DictConfig) -> None:
     last_save_step = 0
     restored_train_state = False
     last_logged_step = 0
+    warmup_only = _apply_training_phase(flow_model, optimizer, scheduler, cfg, step=global_step)
 
     # --- Single-source load policy: checkpoint OR pretrained; fallback to pretrained on errors ---
     if should_try_checkpoint:
@@ -773,12 +800,6 @@ def main(cfg: DictConfig) -> None:
                 global_step = int(client.get("step", 0))
                 images_since_save = int(client.get("images_since_save", 0))
                 last_save_step = global_step
-                new_max = _curriculum_max_sim(cfg, start_epoch)
-                if new_max != max_sim:
-                    max_sim = new_max
-                    train_loader, train_dataset, train_sampler = _build_train_loader(
-                        cfg, corrupt_cfg, max_sim, world_size
-                    )
                 restored_train_state = _restore_train_loader_state(
                     train_loader,
                     train_dataset,
@@ -802,6 +823,13 @@ def main(cfg: DictConfig) -> None:
             images_since_save = 0
             last_save_step = 0
             restored_train_state = False
+    warmup_only = _apply_training_phase(
+        _unwrap_model(engine),
+        engine.optimizer,
+        engine.lr_scheduler if hasattr(engine, "lr_scheduler") else scheduler,
+        cfg,
+        step=global_step,
+    )
     last_logged_step = global_step
     _distributed_barrier()
 
@@ -826,13 +854,6 @@ def main(cfg: DictConfig) -> None:
         if val_sampler is not None:
             val_sampler.set_epoch(epoch)
 
-        curriculum_max_sim = _curriculum_max_sim(cfg, epoch)
-        if not resumed_epoch and curriculum_max_sim != max_sim:
-            max_sim = curriculum_max_sim
-            train_loader, train_dataset, train_sampler = _build_train_loader(
-                cfg, corrupt_cfg, max_sim, world_size
-            )
-
         pbar = tqdm(train_loader, disable=not is_main_process(), desc=f"epoch {epoch}")
         t_last = time.perf_counter()
         for batch in pbar:
@@ -851,6 +872,14 @@ def main(cfg: DictConfig) -> None:
             prev_step = global_step
             global_step = int(getattr(engine, "global_steps", prev_step + 1))
             images_since_save += images_per_opt_step
+            if warmup_only and not _warmup_only_for_step(cfg, global_step):
+                warmup_only = _apply_training_phase(
+                    _unwrap_model(engine),
+                    engine.optimizer,
+                    engine.lr_scheduler if hasattr(engine, "lr_scheduler") else scheduler,
+                    cfg,
+                    step=global_step,
+                )
 
             if is_main_process():
                 pbar.set_postfix(loss=f"{loss.item():.4f}")
@@ -911,7 +940,6 @@ def main(cfg: DictConfig) -> None:
                 client_state = {
                     "step": global_step,
                     "epoch": epoch,
-                    "stage": str(cfg.train.stage),
                     "images_since_save": images_since_save,
                     "train_loader_state": _capture_train_loader_state(
                         train_loader,
@@ -941,7 +969,6 @@ def main(cfg: DictConfig) -> None:
     client_state = {
         "step": global_step,
         "epoch": int(cfg.train.num_epochs),
-        "stage": str(cfg.train.stage),
         "images_since_save": images_since_save,
         "train_loader_state": _capture_train_loader_state(
             train_loader,
@@ -959,8 +986,8 @@ if __name__ == "__main__":
     # ``ds_config.train_micro_batch_size_per_gpu=8``.
     #
     # Examples:
-    #   python -m src.train --config train/configs/train.yaml train.stage=warmup
-    #   python -m src.train train.stage=full ds_config.train_micro_batch_size_per_gpu=8
+    #   python -m src.train --config train/configs/train.yaml train.warmup_iterations=1000
+    #   python -m src.train ds_config.train_micro_batch_size_per_gpu=8
     #   python -m src.train train.resume_from=/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/checkpoints/step_1000
     parser = argparse.ArgumentParser(description="Art restoration DiT training")
     parser.add_argument(

--- a/tests/debug_v4_closeup.py
+++ b/tests/debug_v4_closeup.py
@@ -69,7 +69,7 @@ def overlay(img, mask, color=(255, 60, 60), alpha=0.45):
 def forced_config(base_cfg, channel: str, mode: str, severity: float):
     """Return a cfg forcing exactly one channel, one mode, fixed severity."""
     cfg = deepcopy(base_cfg)
-    cfg.num_simultaneous = {'min': 1, 'max': 1}
+    cfg.active_count_probs = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     for name in CHANNEL_NAMES:
         t = cfg.types[name]
         t.weight = 1.0 if name == channel else 0.0

--- a/tests/smoke_model_forward.py
+++ b/tests/smoke_model_forward.py
@@ -1,0 +1,107 @@
+"""Offline forward-pass smoke test with a tiny random-weight FLUX model.
+
+This does not load any pretrained weights. It only checks that the restoration-style
+input path
+
+    [z_t, z_y, mask] -> tokenization -> Flux2 forward -> reshape
+
+produces the expected output shape.
+
+Usage:
+    ./.venv/bin/python tests/smoke_model_forward.py
+    ./.venv/bin/python tests/smoke_model_forward.py --batch-size 2 --latent-size 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.flux2.model import Flux2, Flux2Params
+from src.flux2.sampling import batched_prc_img, batched_prc_txt
+
+
+def build_tiny_flux(device: torch.device) -> Flux2:
+    params = Flux2Params(
+        in_channels=128,
+        context_in_dim=64,
+        hidden_size=64,
+        num_heads=8,
+        depth=1,
+        depth_single_blocks=1,
+        axes_dim=[2, 2, 2, 2],
+        use_guidance_embed=False,
+    )
+    model = Flux2(params).to(device=device)
+    model.img_in = nn.Linear(264, params.hidden_size, bias=False, device=device)
+    return model.eval()
+
+
+@torch.no_grad()
+def run_smoke_test(batch_size: int, latent_size: int, text_tokens: int, device: torch.device) -> None:
+    torch.manual_seed(0)
+
+    model = build_tiny_flux(device)
+    z_t = torch.randn(batch_size, 128, latent_size, latent_size, device=device)
+    z_y = torch.randn_like(z_t)
+    mask = torch.randint(
+        low=0,
+        high=2,
+        size=(batch_size, 8, latent_size, latent_size),
+        device=device,
+        dtype=torch.int64,
+    ).float()
+    t = torch.rand(batch_size, device=device)
+    null_emb = torch.randn(1, text_tokens, 64, device=device)
+
+    x = torch.cat([z_t, z_y, mask], dim=1)
+    img_tokens, img_ids = batched_prc_img(x)
+    txt_tokens, txt_ids = batched_prc_txt(null_emb.expand(batch_size, -1, -1))
+
+    pred = model(
+        x=img_tokens,
+        x_ids=img_ids,
+        timesteps=t,
+        ctx=txt_tokens,
+        ctx_ids=txt_ids,
+        guidance=None,
+    )
+    vel = rearrange(pred, "b (h w) c -> b c h w", h=latent_size, w=latent_size)
+
+    expected = (batch_size, 128, latent_size, latent_size)
+    if tuple(vel.shape) != expected:
+        raise AssertionError(f"Expected output shape {expected}, got {tuple(vel.shape)}")
+
+    print(
+        "forward smoke test passed:",
+        {
+            "device": str(device),
+            "batch_shape": tuple(x.shape),
+            "token_shape": tuple(img_tokens.shape),
+            "text_shape": tuple(txt_tokens.shape),
+            "output_shape": tuple(vel.shape),
+        },
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Tiny random-weight FLUX forward smoke test")
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--latent-size", type=int, default=8)
+    parser.add_argument("--text-tokens", type=int, default=4)
+    parser.add_argument("--device", type=str, default="cpu")
+    args = parser.parse_args()
+
+    run_smoke_test(
+        batch_size=args.batch_size,
+        latent_size=args.latent_size,
+        text_tokens=args.text_tokens,
+        device=torch.device(args.device),
+    )

--- a/train/configs/train.yaml
+++ b/train/configs/train.yaml
@@ -1,7 +1,7 @@
 # Master training config.
 #
 # Loaded via OmegaConf. CLI dot-notation overrides supported, e.g.
-#     python -m src.train train.stage=full ds_config.train_micro_batch_size_per_gpu=8
+#     python -m src.train train.warmup_iterations=1000 ds_config.train_micro_batch_size_per_gpu=8
 #
 # Separate corruption config at `corruption.config_path` is merged in.
 
@@ -13,9 +13,6 @@ model:
   null_emb_path: "null_text_emb.pt"
 
 train:
-  # "warmup": backbone frozen, only img_in trained
-  # "full":   all layers trained with per-group LRs
-  stage: "warmup"
   train_dir: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/data/train"
   val_dir: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/data/val"
   checkpoint_dir: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/checkpoints"
@@ -29,6 +26,7 @@ train:
   snapshot_every_n_steps: 1
   num_epochs: 50
   seed: 42
+  warmup_iterations: 1000
   save_every: 1000
   val_every: 80
   log_every: 100
@@ -50,10 +48,6 @@ train:
   full:
     backbone_lr: 1e-5
     img_in_lr: 1e-4
-
-  curriculum:
-    enabled: true
-    warmup_epochs: 5
 
 # Corruption pipeline — reference to a separate YAML loaded and merged
 # into cfg.corruption at load time.

--- a/train/scripts/full.sh
+++ b/train/scripts/full.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# Stage 2 training: fine-tune all layers with separate LRs for backbone and img_in.
-# Run after warmup.sh completes and set WARMUP_CKPT to the saved checkpoint path.
+# Resume training from an existing DeepSpeed checkpoint tag directory.
+# If the checkpoint was saved after warm-up, the backbone will already be unfrozen
+# automatically based on `train.warmup_iterations` and the saved global step.
 #
 # Usage:
 #   sbatch train/scripts/full.sh
 #
 # Overrides (append to python command as dot-notation, e.g.):
-#   train.full.backbone_lr=5e-6
+#   train.warmup_iterations=0
 #   train.batch_size=4
 
 #SBATCH --job-name=art-restore-full
@@ -20,9 +21,8 @@
 
 mkdir -p logs
 
-WARMUP_CKPT="checkpoints/warmup_final.pt"
+RESUME_CKPT="checkpoints/step_1000"
 
 python -m src.train \
     --config train/configs/train.yaml \
-    train.stage=full \
-    train.resume_from=${WARMUP_CKPT}
+    train.resume_from=${RESUME_CKPT}

--- a/train/scripts/warmup.sh
+++ b/train/scripts/warmup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Stage 1 training: freeze backbone, train only img_in.
+# Training from scratch. The first `train.warmup_iterations` optimizer steps
+# train `img_in` only; afterward the backbone is unfrozen automatically.
 #
 # Usage:
 #   sbatch train/scripts/warmup.sh
@@ -23,5 +24,4 @@ mkdir -p logs
 # Precompute null text embedding if not already cached
 python -m src.null_emb --config train/configs/train.yaml
 
-# Run warmup stage
-python -m src.train --config train/configs/train.yaml train.stage=warmup
+python -m src.train --config train/configs/train.yaml


### PR DESCRIPTION
Details on what was changed:

1. Corruption Count Sampling: 

- Removed the max_simultaneous functionality from dataset.py and train.py (was buggy). 
- Added active_count_probs to "corruption/configs/default.yaml", which defines the relative probabilities of sampling exactly 1, 2, 3, ..., 7 active degradation types per image.
- Updated CorruptionModule to sample the number of active degradations from active_count_probs, then keep the existing logic for all other sampling (which type, local vs global, severity, mask generation, etc). 
- IMPORTANT: Curriculum learning is removed entirely through this change. Values will need to be manually set for warm up and initial training and final training if we want to implement curriculum learning. This happens through the config file. 

2. Warm up Scheduling: 

- Removed train.stage from the config and replaced it with train.warmup_iterations in train/configs/train.yaml.
- Warm-up is now iteration-based inside a single training run. For the first warmup_iterations optimizer steps, only img_in is trainable. After that, the backbone is automatically unfrozen and full-training learning rates are applied
- Updated the optimizer / trainability logic so resume behaviour is determined from checkpoint step count instead of a stage flag.
- Updated the training scripts and README to match the new behavior.
- IMPORTANT: the warmup_iterations number decides when training switches, no longer staged. But this is flexible! Say we set wamrup_iterations=1000, and then train for 1000 iterations. Now we decide that more warm up is needed. We can update wamrup_iterations=3000 in the config file and resume training. The code can handle this case automatically - weights will remain frozen until 3000. 

3. New Forward Pass Test:

- Created a new test file to check tensor shapes. 
- This script does not load FLUX or any pretrained weights.
- It builds a tiny random-weight Flux2 model, replaces img_in to accept [z_t, z_y, mask], runs the same tokenization/forward/reshape path as training, and checks that output shapes are correct.

- Have not run this script yet. If someone else can do that would be great. 