### PR TITLE
Gradio inference server + mask painter updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Thumbs.db
 .idea/
 *.png
 *.jpg
+inference/scripts/gradio.sh

--- a/inference/configs/inference.yaml
+++ b/inference/configs/inference.yaml
@@ -14,14 +14,15 @@ inference:
   input_dir: "./data/test"
   output_dir: "./results"
   mask_dir: ""  # populated by mask_painter.py
+  resolution: 512   # must match train.yaml.train.resolution (divisible by 16)
   num_steps: 50
   guidance: 4.0
   device: "cuda"
   damage_types:
-    - cracks
+    - craquelure
+    - rip_tear
     - paint_loss
     - yellowing
-    - stains
     - fading
     - deposits
     - scratches

--- a/inference/configs/inference.yaml
+++ b/inference/configs/inference.yaml
@@ -16,7 +16,6 @@ inference:
   mask_dir: ""  # populated by mask_painter.py
   resolution: 512   # must match train.yaml.train.resolution (divisible by 16)
   num_steps: 50
-  guidance: 4.0
   device: "cuda"
   damage_types:
     - craquelure

--- a/inference/gradio_server.py
+++ b/inference/gradio_server.py
@@ -404,15 +404,15 @@ class GradioApp:
 
     # -- UI ------------------------------------------------------------------
 
+    # theme / css are passed to launch() in Gradio 6.0+, not Blocks().
+    THEME = gr.themes.Soft(primary_hue="emerald", neutral_hue="slate")
+    CSS = (
+        ".gradio-container { max-width: 1600px !important; } "
+        "#mask-editor canvas { background: #1a1a1a; }"
+    )
+
     def build_ui(self) -> gr.Blocks:
-        with gr.Blocks(
-            title="Art Restoration",
-            theme=gr.themes.Soft(primary_hue="emerald", neutral_hue="slate"),
-            css="""
-            .gradio-container { max-width: 1600px !important; }
-            #mask-editor canvas { background: #1a1a1a; }
-            """,
-        ) as demo:
+        with gr.Blocks(title="Art Restoration") as demo:
             state = gr.State()
 
             gr.Markdown(
@@ -561,11 +561,17 @@ def main() -> None:
     device = args.device or cfg.inference.get("device", "cuda")
     app = GradioApp(cfg=cfg, checkpoint=args.checkpoint, device=device)
     demo = app.build_ui()
+    log_message(
+        f"[gradio] launching on http://{args.host}:{args.port} "
+        f"(share={args.share}); look for 'Running on ... URL' below"
+    )
     demo.launch(
         server_name=args.host,
         server_port=args.port,
         share=bool(args.share),
         show_error=True,
+        theme=GradioApp.THEME,
+        css=GradioApp.CSS,
     )
 
 

--- a/inference/gradio_server.py
+++ b/inference/gradio_server.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Gradio web server: upload → paint damage masks → restore.
+
+One-stop inference UI combining :mod:`tools.mask_painter`-style multi-channel
+painting with the Euler ODE sampler from :mod:`src.inference`. The uploaded
+image is resized (center-crop + bicubic) to ``cfg.inference.resolution`` before
+the user sees it, so masks are drawn in the exact pixel grid the model
+consumes. The original file on disk is never modified.
+
+Usage (from repo root):
+    python inference/gradio_server.py --config inference/configs/inference.yaml
+
+``--checkpoint`` overrides ``cfg.inference.checkpoint`` if provided. Accepts
+either format:
+
+* A single-file ``torch.save``-ed state_dict of :class:`~src.model.RestorationDiT`
+  (optionally wrapped under a ``"module"`` / ``"model"`` / ``"state_dict"`` key).
+* A DeepSpeed checkpoint directory as written by ``engine.save_checkpoint``
+  (contains a ``latest`` file pointing at a tag subdirectory, e.g.
+  ``checkpoints/run_foo/step_1000/mp_rank_00_model_states.pt``). Both ZeRO-2
+  (weights replicated in ``mp_rank_00_model_states.pt``) and ZeRO-3
+  (weights sharded, consolidated via ``zero_to_fp32``) layouts are supported.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import torch
+from PIL import Image, ImageOps
+
+import gradio as gr
+
+from src.utils import log_message
+from src.model import RestorationDiT
+from src.vae import FluxVAE
+from src.null_emb import load_or_compute_null_embedding
+from src.inference import data_consistency_step
+from src.corruption import CHANNEL_NAMES, NUM_CHANNELS, downsample_mask
+from src.flux2.sampling import get_schedule
+
+
+# Per-channel overlay colors (RGB). Mirrors tools/mask_painter.py CHANNELS.
+CHANNEL_COLORS: Dict[str, Tuple[int, int, int]] = {
+    "craquelure": (255, 80, 80),
+    "rip_tear":   (230, 50, 50),
+    "paint_loss": (240, 150, 40),
+    "yellowing":  (240, 230, 60),
+    "fading":     (180, 180, 255),
+    "deposits":   (160, 140, 100),
+    "scratches":  (220, 100, 220),
+}
+OVERLAY_ALPHA = 0.45
+
+
+# ---------------------------------------------------------------------------
+# Preprocessing / mask helpers
+# ---------------------------------------------------------------------------
+
+def _resize_square(img: Image.Image, resolution: int) -> Image.Image:
+    """Center-crop to square, bicubic-resize to ``resolution x resolution``.
+
+    Matches ``src.dataset._crop_resize_to_tensor`` (PIL path) so the image
+    shown in the UI is the same image the model sees.
+    """
+    img = ImageOps.exif_transpose(img).convert("RGB")
+    w, h = img.size
+    crop = min(w, h)
+    top = max((h - crop) // 2, 0)
+    left = max((w - crop) // 2, 0)
+    img = img.crop((left, top, left + crop, top + crop))
+    return img.resize((int(resolution), int(resolution)), Image.BICUBIC)
+
+
+def _mask_from_layer(layer: Optional[np.ndarray]) -> Optional[np.ndarray]:
+    """Extract a binary (H, W) uint8 mask from a Gradio ImageEditor layer.
+
+    Returns ``None`` if ``layer`` is missing. Gradio encodes user strokes as
+    RGBA with the alpha channel set where the brush painted.
+    """
+    if layer is None:
+        return None
+    arr = np.asarray(layer)
+    if arr.ndim == 3 and arr.shape[-1] == 4:
+        return (arr[..., 3] > 0).astype(np.uint8)
+    if arr.ndim == 3:
+        return (arr.sum(axis=-1) > 0).astype(np.uint8)
+    return (arr > 0).astype(np.uint8)
+
+
+def _layer_from_mask(mask: np.ndarray, color: Tuple[int, int, int]) -> np.ndarray:
+    """Render a binary mask as an RGBA layer painted in ``color`` (fully opaque)."""
+    h, w = mask.shape
+    layer = np.zeros((h, w, 4), dtype=np.uint8)
+    where = mask.astype(bool)
+    layer[where, 0] = color[0]
+    layer[where, 1] = color[1]
+    layer[where, 2] = color[2]
+    layer[where, 3] = 255
+    return layer
+
+
+def _composite_other_channels(
+    image: np.ndarray,
+    masks: Dict[int, np.ndarray],
+    active_ch: int,
+) -> np.ndarray:
+    """Bake per-channel colored overlays for all channels EXCEPT ``active_ch``
+    into the background, so the editor always shows accumulated damage context
+    while the user edits one channel in isolation.
+    """
+    bg = image.astype(np.float32).copy()
+    for ch in range(NUM_CHANNELS):
+        if ch == active_ch:
+            continue
+        mask = masks[ch]
+        if mask.max() == 0:
+            continue
+        color = CHANNEL_COLORS[CHANNEL_NAMES[ch]]
+        alpha = mask.astype(np.float32) * OVERLAY_ALPHA
+        for c_idx in range(3):
+            bg[..., c_idx] = bg[..., c_idx] * (1.0 - alpha) + color[c_idx] * alpha
+    return np.clip(bg, 0, 255).astype(np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint loading (single-file or DeepSpeed directory)
+# ---------------------------------------------------------------------------
+
+def _unwrap_state_dict(blob: Any) -> Dict[str, torch.Tensor]:
+    """Peel common wrapper keys (``"module"``, ``"model"``, ``"state_dict"``)
+    off a loaded object and strip a leading ``module.`` prefix from all keys.
+
+    Leaves tensor values untouched. Returns a plain ``{str: Tensor}`` dict.
+    """
+    sd = blob
+    if isinstance(sd, dict):
+        for key in ("module", "model", "state_dict"):
+            if key in sd and isinstance(sd[key], dict):
+                sd = sd[key]
+                break
+    if not isinstance(sd, dict):
+        raise TypeError(f"Expected state_dict mapping, got {type(sd).__name__}")
+    if any(isinstance(k, str) and k.startswith("module.") for k in sd.keys()):
+        sd = {
+            (k[len("module."):] if isinstance(k, str) and k.startswith("module.") else k): v
+            for k, v in sd.items()
+        }
+    return sd
+
+
+def _load_checkpoint_state_dict(
+    ckpt_path: str,
+    map_location: torch.device,
+) -> Dict[str, torch.Tensor]:
+    """Load a :class:`RestorationDiT` state_dict from either layout.
+
+    * If ``ckpt_path`` is a directory, treat it as a DeepSpeed checkpoint root.
+      Resolve the active tag via the ``latest`` file (or assume ``ckpt_path``
+      itself is already the tag dir). Prefer the ZeRO-2 fast path
+      (``mp_rank_00_model_states.pt["module"]``); fall back to
+      ``zero_to_fp32.get_fp32_state_dict_from_zero_checkpoint`` for ZeRO-3.
+    * If ``ckpt_path`` is a file, ``torch.load`` it and unwrap common wrappers.
+    """
+    p = Path(ckpt_path)
+    if p.is_dir():
+        latest_file = p / "latest"
+        if latest_file.exists():
+            tag = latest_file.read_text().strip()
+            tag_dir = p / tag
+            root_dir = p
+        else:
+            tag_dir = p
+            root_dir = p.parent
+            tag = p.name
+        shard = tag_dir / "mp_rank_00_model_states.pt"
+        if shard.exists():
+            log_message(f"[gradio] loading DeepSpeed shard {shard}")
+            blob = torch.load(str(shard), map_location=map_location, weights_only=False)
+            return _unwrap_state_dict(blob)
+        # ZeRO-3 fallback: consolidate sharded weights on the fly.
+        log_message(
+            f"[gradio] no mp_rank_00 shard; consolidating ZeRO shards from {root_dir} (tag={tag})"
+        )
+        from deepspeed.utils.zero_to_fp32 import (  # local import: heavy dep
+            get_fp32_state_dict_from_zero_checkpoint,
+        )
+        sd = get_fp32_state_dict_from_zero_checkpoint(str(root_dir), tag=tag)
+        return _unwrap_state_dict(sd)
+
+    log_message(f"[gradio] loading checkpoint file {p}")
+    blob = torch.load(str(p), map_location=map_location, weights_only=False)
+    return _unwrap_state_dict(blob)
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+class GradioApp:
+    """Single-session inference app: loads weights once at startup."""
+
+    def __init__(self, cfg, checkpoint: Optional[str] = None, device: str = "cuda"):
+        self.cfg = cfg
+        self.device = torch.device(device)
+        self.resolution = int(cfg.inference.resolution)
+        self.num_steps_default = int(cfg.inference.get("num_steps", 50))
+
+        ckpt_path = checkpoint or cfg.inference.checkpoint
+        if not ckpt_path or not Path(str(ckpt_path)).exists():
+            raise FileNotFoundError(
+                f"Checkpoint not found: {ckpt_path!r}. "
+                "Set cfg.inference.checkpoint (or pass --checkpoint) to either a "
+                "single-file state_dict or a DeepSpeed checkpoint directory."
+            )
+
+        log_message(f"[gradio] loading RestorationDiT from {ckpt_path}")
+        self.model = RestorationDiT(
+            cfg=cfg.model,
+            gradient_checkpointing=False,
+            device=self.device,
+            img_in_dtype=torch.bfloat16,
+            load_pretrained=False,
+            rank=0,
+        )
+        state = _load_checkpoint_state_dict(str(ckpt_path), map_location=self.device)
+        missing, unexpected = self.model.load_state_dict(state, strict=False)
+        if missing:
+            log_message(f"[gradio] WARN {len(missing)} missing checkpoint keys (showing first 4): {missing[:4]}")
+        if unexpected:
+            log_message(f"[gradio] WARN {len(unexpected)} unexpected keys (showing first 4): {unexpected[:4]}")
+        self.model.eval()
+
+        log_message("[gradio] loading VAE")
+        self.vae = FluxVAE(
+            flux_model_name=cfg.model.flux_model_name,
+            rank=0,
+            device=str(self.device),
+        ).to(self.device).eval()
+
+        log_message("[gradio] loading null embedding")
+        self.null_emb = load_or_compute_null_embedding(
+            cache_path=cfg.model.null_emb_path,
+            flux_model_name=cfg.model.flux_model_name,
+            device=self.device,
+        )
+        log_message("[gradio] ready.")
+
+    # -- callbacks -----------------------------------------------------------
+
+    def on_upload(self, pil_image: Optional[Image.Image]):
+        """Resize the uploaded image and initialize the mask state."""
+        if pil_image is None:
+            return gr.update(value=None), None, None
+        resized = _resize_square(pil_image, self.resolution)
+        bg = np.array(resized)
+        masks = {
+            ch: np.zeros((self.resolution, self.resolution), dtype=np.uint8)
+            for ch in range(NUM_CHANNELS)
+        }
+        state = {"image": bg, "masks": masks, "active_ch": 0}
+        editor_value = {
+            "background": _composite_other_channels(bg, masks, 0),
+            "layers": [np.zeros((self.resolution, self.resolution, 4), dtype=np.uint8)],
+            "composite": bg,
+        }
+        return gr.update(value=editor_value), state, None
+
+    def on_channel_change(self, ch_name: str, editor: Any, state: Optional[dict]):
+        """Swap the painting canvas to the selected channel.
+
+        Persists the current layer into ``state["masks"][old_ch]``, then
+        rebuilds the editor with a background containing every OTHER channel's
+        colored overlay plus a fresh layer holding the target channel's
+        existing strokes.
+        """
+        if state is None:
+            return gr.update(), state
+        new_ch = CHANNEL_NAMES.index(ch_name)
+        old_ch = int(state["active_ch"])
+        if editor is not None and editor.get("layers"):
+            painted = _mask_from_layer(editor["layers"][0])
+            if painted is not None:
+                state["masks"][old_ch] = painted
+        state["active_ch"] = new_ch
+
+        bg_other = _composite_other_channels(state["image"], state["masks"], new_ch)
+        new_layer = _layer_from_mask(
+            state["masks"][new_ch],
+            CHANNEL_COLORS[ch_name],
+        )
+        editor_value = {
+            "background": bg_other,
+            "layers": [new_layer],
+            "composite": bg_other,
+        }
+        return gr.update(value=editor_value), state
+
+    def on_clear_channel(self, editor: Any, state: Optional[dict]):
+        """Clear strokes on the current channel."""
+        if state is None:
+            return gr.update(), state
+        ch = int(state["active_ch"])
+        state["masks"][ch] = np.zeros(
+            (self.resolution, self.resolution), dtype=np.uint8
+        )
+        bg_other = _composite_other_channels(state["image"], state["masks"], ch)
+        editor_value = {
+            "background": bg_other,
+            "layers": [np.zeros((self.resolution, self.resolution, 4), dtype=np.uint8)],
+            "composite": bg_other,
+        }
+        return gr.update(value=editor_value), state
+
+    def on_generate(
+        self,
+        editor: Any,
+        state: Optional[dict],
+        num_steps: float,
+        progress: gr.Progress = gr.Progress(),
+    ):
+        """Assemble the (1, 8, R, R) mask tensor and run the Euler sampler."""
+        if state is None:
+            raise gr.Error("Upload an image first.")
+        # Save the current channel's strokes before consuming the state.
+        if editor is not None and editor.get("layers"):
+            painted = _mask_from_layer(editor["layers"][0])
+            if painted is not None:
+                state["masks"][int(state["active_ch"])] = painted
+
+        # Per-channel masks (7, R, R) + union channel (1, R, R) -> (8, R, R).
+        per_ch = np.stack(
+            [state["masks"][c] for c in range(NUM_CHANNELS)], axis=0
+        ).astype(np.float32)
+        union = per_ch.max(axis=0, keepdims=True)
+        mask_np = np.concatenate([per_ch, union], axis=0)  # (8, R, R)
+        if mask_np[-1].max() < 0.5:
+            raise gr.Error(
+                "No damage mask painted. Paint at least one stroke on any "
+                "channel before generating."
+            )
+        mask_t = torch.from_numpy(mask_np).unsqueeze(0).to(self.device)
+
+        img_np = state["image"].astype(np.float32) / 255.0  # (R, R, 3)
+        img_t = (
+            torch.from_numpy(img_np)
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .to(self.device)
+        )
+
+        restored = self._run_inference(img_t, mask_t, int(num_steps), progress)
+        out = (
+            restored[0]
+            .clamp(0.0, 1.0)
+            .permute(1, 2, 0)
+            .cpu()
+            .float()
+            .numpy()
+            * 255.0
+        ).round().astype(np.uint8)
+        return out, state
+
+    # -- inference -----------------------------------------------------------
+
+    @torch.no_grad()
+    def _run_inference(
+        self,
+        corrupted_image: torch.Tensor,
+        mask: torch.Tensor,
+        num_steps: int,
+        progress: gr.Progress,
+    ) -> torch.Tensor:
+        """Inlined equivalent of :func:`src.inference.sample` with progress."""
+        device = self.device
+        progress(0.02, desc="Encoding with VAE...")
+        z_y = self.vae.encode(corrupted_image.to(device))
+        m_lat = downsample_mask(mask.to(device), factor=self.vae.spatial_compression)
+        b, _, h, w = z_y.shape
+        z_t = torch.randn_like(z_y)
+        seq_len = h * w
+        timesteps = get_schedule(num_steps, seq_len)
+
+        dtype = torch.bfloat16 if z_t.device.type == "cuda" else torch.float32
+        z_t = z_t.to(dtype=dtype)
+        z_y = z_y.to(dtype=dtype)
+        m_lat = m_lat.to(dtype=dtype)
+        null_b = self.null_emb.to(device=device, dtype=dtype)
+
+        z_t = data_consistency_step(z_t, z_y, m_lat)
+        total = max(1, len(timesteps) - 1)
+        for i, (t_curr, t_next) in enumerate(zip(timesteps[:-1], timesteps[1:])):
+            progress((i + 1) / (total + 1), desc=f"Denoising {i + 1}/{total}")
+            t_vec = torch.full((b,), float(t_curr), device=device, dtype=dtype)
+            vel = self.model(z_t, t_vec, z_y, m_lat, null_b)
+            z_t = z_t + (float(t_next) - float(t_curr)) * vel
+            z_t = data_consistency_step(z_t, z_y, m_lat)
+
+        progress(1.0, desc="Decoding with VAE...")
+        restored = self.vae.decode(z_t.float())
+        return restored.clamp(0.0, 1.0)
+
+    # -- UI ------------------------------------------------------------------
+
+    def build_ui(self) -> gr.Blocks:
+        with gr.Blocks(
+            title="Art Restoration",
+            theme=gr.themes.Soft(primary_hue="emerald", neutral_hue="slate"),
+            css="""
+            .gradio-container { max-width: 1600px !important; }
+            #mask-editor canvas { background: #1a1a1a; }
+            """,
+        ) as demo:
+            state = gr.State()
+
+            gr.Markdown(
+                "# Art Restoration\n"
+                "Upload a damaged artwork, paint per-type damage masks, then "
+                "generate a restored image. The upload is center-cropped and "
+                f"resized to **{self.resolution}×{self.resolution}** so masks "
+                "are pixel-aligned with the model's input grid."
+            )
+
+            with gr.Row():
+                with gr.Column(scale=1, min_width=280):
+                    upload = gr.Image(
+                        label="1. Upload image",
+                        type="pil",
+                        sources=["upload", "clipboard"],
+                        height=220,
+                    )
+                    channel = gr.Radio(
+                        choices=list(CHANNEL_NAMES),
+                        value=CHANNEL_NAMES[0],
+                        label="2. Damage type",
+                        info="Paint strokes apply to the selected channel. "
+                             "Switching channels preserves each channel's strokes.",
+                    )
+                    clear_btn = gr.Button("Clear current channel", size="sm")
+                    num_steps = gr.Slider(
+                        minimum=10,
+                        maximum=100,
+                        value=self.num_steps_default,
+                        step=1,
+                        label="3. Inference steps",
+                    )
+                    generate_btn = gr.Button(
+                        "Restore",
+                        variant="primary",
+                        size="lg",
+                    )
+                    gr.Markdown(
+                        "_Tip: unpainted channels are zero-filled; the union "
+                        "channel is computed automatically as the pixel-wise "
+                        "max over all per-type channels._"
+                    )
+
+                with gr.Column(scale=2, min_width=400):
+                    editor = gr.ImageEditor(
+                        label="Paint masks",
+                        type="numpy",
+                        image_mode="RGB",
+                        sources=(),
+                        interactive=True,
+                        brush=gr.Brush(
+                            default_size=15,
+                            colors=["#ffffff"],
+                            default_color="#ffffff",
+                            color_mode="fixed",
+                        ),
+                        eraser=gr.Eraser(default_size=15),
+                        canvas_size=(self.resolution, self.resolution),
+                        elem_id="mask-editor",
+                        height=self.resolution + 80,
+                    )
+
+                with gr.Column(scale=2, min_width=400):
+                    output_img = gr.Image(
+                        label="Restored",
+                        type="numpy",
+                        interactive=False,
+                        height=self.resolution + 80,
+                    )
+
+            upload.change(
+                fn=self.on_upload,
+                inputs=[upload],
+                outputs=[editor, state, output_img],
+            )
+            channel.change(
+                fn=self.on_channel_change,
+                inputs=[channel, editor, state],
+                outputs=[editor, state],
+            )
+            clear_btn.click(
+                fn=self.on_clear_channel,
+                inputs=[editor, state],
+                outputs=[editor, state],
+            )
+            generate_btn.click(
+                fn=self.on_generate,
+                inputs=[editor, state, num_steps],
+                outputs=[output_img, state],
+            )
+
+        demo.queue(max_size=8)
+        return demo
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Gradio server for art restoration inference.")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="inference/configs/inference.yaml",
+        help="Path to inference YAML (default: inference/configs/inference.yaml).",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default=None,
+        help="Override cfg.inference.checkpoint with this state_dict path.",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Bind address (default: 0.0.0.0).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=7860,
+        help="Port to serve on (default: 7860).",
+    )
+    parser.add_argument(
+        "--share",
+        action="store_true",
+        help="Create a public *.gradio.live tunnel.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Override device (default: cfg.inference.device or 'cuda').",
+    )
+    args = parser.parse_args()
+
+    # Inference YAML has no ``corruption`` key, so don't route it through
+    # ``src.utils.load_config`` (which requires ``corruption.config_path``).
+    # The plain OmegaConf load is sufficient here.
+    from omegaconf import OmegaConf
+    cfg = OmegaConf.load(args.config)
+
+    device = args.device or cfg.inference.get("device", "cuda")
+    app = GradioApp(cfg=cfg, checkpoint=args.checkpoint, device=device)
+    demo = app.build_ui()
+    demo.launch(
+        server_name=args.host,
+        server_port=args.port,
+        share=bool(args.share),
+        show_error=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tqdm>=4.65.0
 omegaconf>=2.3.0
 wandb>=0.17.0
 deepspeed>=0.14.0
+gradio>=4.36.0

--- a/tools/mask_painter.py
+++ b/tools/mask_painter.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse, parse_qs
 
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageOps
 
 try:
     import torch
@@ -54,18 +54,45 @@ CHANNELS = [
     ("scratches",  (220, 100, 220)),
 ]
 NUM_CHANNELS = len(CHANNELS)
+# Total output channels saved to disk: NUM_CHANNELS per-type + 1 union channel.
+# Matches src.corruption.OUTPUT_MASK_CHANNELS.
+OUTPUT_MASK_CHANNELS = NUM_CHANNELS + 1
 OVERLAY_ALPHA = 0.45
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".bmp"}
+DEFAULT_RESOLUTION = 512
+
+
+def _resize_for_painting(img: Image.Image, resolution: int) -> Image.Image:
+    """Center-crop to square and resize to ``resolution x resolution``.
+
+    Mirrors ``src.dataset._crop_resize_to_tensor`` so the image the user paints
+    over is pixel-aligned with what the model sees during training / inference.
+    The original file on disk is NOT modified.
+    """
+    img = ImageOps.exif_transpose(img).convert("RGB")
+    w, h = img.size
+    crop = min(w, h)
+    top = max((h - crop) // 2, 0)
+    left = max((w - crop) // 2, 0)
+    img = img.crop((left, top, left + crop, top + crop))
+    return img.resize((int(resolution), int(resolution)), Image.BICUBIC)
 
 # ---------------------------------------------------------------------------
 # Global state
 # ---------------------------------------------------------------------------
 
 class ServerState:
-    def __init__(self, images: List[Path], output_dir: Path, config_path: Optional[Path]):
+    def __init__(
+        self,
+        images: List[Path],
+        output_dir: Path,
+        config_path: Optional[Path],
+        resolution: int = DEFAULT_RESOLUTION,
+    ):
         self.images = images
         self.output_dir = output_dir
         self.config_path = config_path
+        self.resolution = int(resolution)
         self.finalized: Dict[int, bool] = {i: False for i in range(len(images))}
         # masks[image_id][channel_idx] = base64 encoded PNG data (or None)
         self.masks: Dict[int, Dict[int, Optional[str]]] = {
@@ -908,14 +935,20 @@ class MaskPainterHandler(BaseHTTPRequestHandler):
                 self._send_error(404, "Image not found")
                 return
             img_path = STATE.images[img_id]
-            mime = mimetypes.guess_type(str(img_path))[0] or "image/jpeg"
+            # Serve the resized (resolution x resolution) square version so the
+            # client paints masks in the same pixel grid the model consumes.
+            # The original file on disk is NOT modified.
             try:
-                data = img_path.read_bytes()
+                with Image.open(img_path) as src:
+                    resized = _resize_for_painting(src, STATE.resolution)
+                buf = io.BytesIO()
+                resized.save(buf, format="PNG")
+                data = buf.getvalue()
             except Exception as e:
                 self._send_error(500, str(e))
                 return
             self.send_response(200)
-            self.send_header("Content-Type", mime)
+            self.send_header("Content-Type", "image/png")
             self.send_header("Content-Length", str(len(data)))
             self.send_header("Cache-Control", "no-cache")
             self.end_headers()
@@ -985,30 +1018,39 @@ class MaskPainterHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 
 def save_all_masks(state: ServerState):
-    """Save all masks to disk and update config."""
+    """Save all masks to disk and update config.
+
+    Masks are stored at ``state.resolution x state.resolution`` — the same pixel
+    grid the client paints on and the model consumes. The saved tensor has
+    shape ``(OUTPUT_MASK_CHANNELS, R, R)``: NUM_CHANNELS per-type channels
+    followed by a union channel (pixel-wise max), matching
+    :data:`src.corruption.OUTPUT_MASK_CHANNELS`.
+    """
     state.output_dir.mkdir(parents=True, exist_ok=True)
+    R = int(state.resolution)
 
     for img_id, img_path in enumerate(state.images):
         stem = img_path.stem
         img_dir = state.output_dir / stem
         img_dir.mkdir(parents=True, exist_ok=True)
 
-        # Load original image for overlay
-        orig = Image.open(img_path).convert("RGB")
-        img_w, img_h = orig.size
+        # Resized (in-memory) copy of the source; original file on disk is untouched.
+        with Image.open(img_path) as src:
+            resized = _resize_for_painting(src, R)
 
         mask_arrays = []
         for ch in range(NUM_CHANNELS):
             mask_data = state.masks[img_id].get(ch)
             if mask_data is not None and isinstance(mask_data, tuple):
                 arr, w, h = mask_data
-                # Resize if needed
-                if w != img_w or h != img_h:
-                    mask_img = Image.fromarray(arr * 255).resize((img_w, img_h), Image.NEAREST)
+                # Client painted at the resolution we served. If (somehow) the
+                # size disagrees, resample with nearest so mask pixels remain {0, 1}.
+                if w != R or h != R:
+                    mask_img = Image.fromarray(arr * 255).resize((R, R), Image.NEAREST)
                     arr = (np.array(mask_img) > 127).astype(np.uint8)
                 mask_arrays.append(arr)
             else:
-                mask_arrays.append(np.zeros((img_h, img_w), dtype=np.uint8))
+                mask_arrays.append(np.zeros((R, R), dtype=np.uint8))
 
         # Save individual PNGs
         for ch in range(NUM_CHANNELS):
@@ -1016,8 +1058,12 @@ def save_all_masks(state: ServerState):
             png_path = img_dir / f"mask_{name}.png"
             Image.fromarray(mask_arrays[ch] * 255).save(png_path)
 
-        # Save combined tensor
-        stacked = np.stack(mask_arrays, axis=0).astype(np.float32)
+        # Save combined tensor with the union channel appended.
+        per_channel = np.stack(mask_arrays, axis=0).astype(np.float32)
+        union = per_channel.max(axis=0, keepdims=True)
+        stacked = np.concatenate([per_channel, union], axis=0)  # (8, R, R)
+        # Union channel PNG for visual debugging.
+        Image.fromarray((union[0] * 255).astype(np.uint8)).save(img_dir / "mask_union.png")
         if torch is not None:
             tensor = torch.from_numpy(stacked)
             torch.save(tensor, img_dir / "masks.pt")
@@ -1025,8 +1071,8 @@ def save_all_masks(state: ServerState):
             np.save(img_dir / "masks.npy", stacked)
             print(f"  Warning: torch not available, saved {stem}/masks.npy instead of .pt")
 
-        # Save overlay
-        overlay = np.array(orig, dtype=np.float32)
+        # Save overlay against the RESIZED image so mask and image are aligned.
+        overlay = np.array(resized, dtype=np.float32)
         for ch in range(NUM_CHANNELS):
             mask = mask_arrays[ch].astype(np.float32)
             if mask.max() == 0:
@@ -1123,12 +1169,18 @@ def main():
         "--port", type=int, default=0,
         help="Port to run server on (default: auto-select).",
     )
+    parser.add_argument(
+        "--resolution", type=int, default=None,
+        help=f"Resize images to this square size before painting "
+             f"(default: inference.yaml.inference.resolution or {DEFAULT_RESOLUTION}).",
+    )
     args = parser.parse_args()
 
     # Determine images and output dir
     image_paths = []
     output_dir = Path(args.output_dir)
     config_path = None
+    resolution = DEFAULT_RESOLUTION
 
     if args.config:
         config_path = Path(args.config)
@@ -1144,6 +1196,7 @@ def main():
             config = yaml.safe_load(f)
 
         inference_cfg = config.get("inference", {})
+        resolution = int(inference_cfg.get("resolution", DEFAULT_RESOLUTION))
         input_dir = Path(inference_cfg.get("input_dir", "./data/test"))
 
         # Resolve relative paths to CWD (not config file location)
@@ -1174,11 +1227,16 @@ def main():
         print("Error: Provide --config or --images")
         sys.exit(1)
 
+    # Explicit CLI --resolution wins over whatever the config said.
+    if args.resolution is not None:
+        resolution = int(args.resolution)
+
     print(f"Found {len(image_paths)} images:")
     for p in image_paths:
         print(f"  {p.name}")
+    print(f"Serving / saving masks at resolution {resolution}x{resolution}.")
 
-    STATE = ServerState(image_paths, output_dir, config_path)
+    STATE = ServerState(image_paths, output_dir, config_path, resolution=resolution)
 
     port = args.port if args.port else find_free_port()
     server = HTTPServer(("0.0.0.0", port), MaskPainterHandler)

--- a/train/configs/train.yaml
+++ b/train/configs/train.yaml
@@ -10,12 +10,12 @@ model:
   spatial_compression: 16      # 8x encoder downsample * 2x patchify
   in_channels: 264             # 128 (z_t) + 128 (z_y) + 8 (mask: 7 types + union)
   hidden_size: 3072
-  null_emb_path: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/null_emb/null_text_emb.pt"
+  null_emb_path: "/nfs/roberts/home/ckk25/project_pi_jl2994/ckk25/null_emb.pt"  
 
 train:
-  train_dir: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/data/train"
-  val_dir: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/data/val"
-  checkpoint_root: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/checkpoints"
+  train_dir: "/nfs/roberts/home/ckk25/project_pi_jl2994/ckk25/data/train" 
+  val_dir: "/nfs/roberts/home/ckk25/project_pi_jl2994/ckk25/data/val" 
+  checkpoint_root: "/nfs/roberts/home/ckk25/project_pi_jl2994/ckk25/checkpoints" 
   resolution: 512
   batch_size: 32
   gradient_checkpointing: true
@@ -29,12 +29,12 @@ train:
   num_epochs: 10
   seed: 42
   debug_vram: true
-  warmup_iterations: 317
-  save_every: 50
-  val_every: 50
-  log_every: 3
-  inspect_data_every: 1 
-  inspect_data_root: "/nfs/roberts/project/cpsc4520/cpsc4520_ckk25/inspect_train_data/"
+  warmup_iterations: 633
+  save_every: 100
+  val_every: 100
+  log_every: 5
+  inspect_data_every: 100
+  inspect_data_root: "/nfs/roberts/home/ckk25/project_pi_jl2994/ckk25/inspect_data" 
   loss_weight_mask: 0.7
   resume_from: null
 
@@ -69,10 +69,10 @@ wandb:
   enabled: true
   project: "V1 Training"
   entity: "cpsc4520_final_project"
-  run_name: "first_run"          # null = auto-generated
+  run_name: "fixed_inference_4_21_4_22_unfixed_corruption_module"          
   tags: []                
   log_images: true
-  log_images_every: 50
+  log_images_every: 100
   log_images_num: 16
 
 # DeepSpeed launcher config. Consumed by deepspeed.initialize(config=cfg.ds_config).
@@ -82,7 +82,7 @@ ds_config:
   train_micro_batch_size_per_gpu: 32
   gradient_accumulation_steps: 1
   gradient_clipping: 1.0
-  steps_per_print: 50
+  steps_per_print: 100
   bf16:
     enabled: true
   zero_optimization:
@@ -91,3 +91,4 @@ ds_config:
     contiguous_gradients: true
     reduce_bucket_size: 500000000
     allgather_bucket_size: 500000000
+


### PR DESCRIPTION
## Summary
- Add `inference/gradio_server.py` — single-GPU Gradio UI for interactive damage-mask painting + Euler-ODE restoration. Per-channel painting UX, union-mask assembly, progress bar, supports both DeepSpeed-directory and single-file checkpoints.
- Update `tools/mask_painter.py` to resize served images to `cfg.inference.resolution` (center-crop + bicubic, matching training), save masks at that resolution, and include the union channel.
- `inference/configs/inference.yaml`: add `resolution`, update damage_types to current 7 `CHANNEL_NAMES`, drop unused `guidance`, fix `theme`/`css` pass-through for Gradio 6.0.
- `requirements.txt`: add `gradio>=4.36.0`.
- Gitignore local `inference/scripts/gradio.sh` (cluster-specific SLURM launcher).

Cherry-picked onto main from the `calder/inference` branch (which had diverged from main's rewritten history).

## Test plan
- [ ] `sbatch inference/scripts/gradio.sh` on the cluster → expect `Running on public URL: https://*.gradio.live` in `slurm-<jobid>.out`.
- [ ] Upload image; confirm it displays at `resolution x resolution`.
- [ ] Paint masks across multiple channels; switching channels preserves strokes.
- [ ] Click Restore; progress bar advances and restored image renders.
- [ ] Works with both a DeepSpeed checkpoint directory and a single-file state_dict.